### PR TITLE
Various fixes

### DIFF
--- a/chart/service-broker/README.md
+++ b/chart/service-broker/README.md
@@ -57,7 +57,6 @@ The following table lists the configurable parameters of the AppsCode Service Br
 | `resources`         | CPU/Memory resource requests/limits                                 | `{}`               |
 | `catalogs.names`    | List of catalogs                                                    | `["kubedb"]`       |
 | `catalogs.path`     | The path where catalogs for different database service plans are stored          | `/etc/config/catalogs`       |
-| `storageClass`      | StorageClassName for storage                                        | `standard`         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/service-broker/templates/deployment.yaml
+++ b/chart/service-broker/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
             - -v
             - "{{ .Values.logLabel }}"
             - --logtostderr
-            - --storage-class
-            - "{{ .Values.storageClass }}"
           ports:
             - name: http
               containerPort: {{ .Values.containerPort }}

--- a/chart/service-broker/values.yaml
+++ b/chart/service-broker/values.yaml
@@ -26,7 +26,7 @@ imagePullSecrets: []
 containerPort: 8080
 
 ## Log level for operator
-logLabel: 5
+logLabel: 3
 
 service:
   ## Specify the type of service
@@ -57,6 +57,3 @@ catalogs:
 
   # The path where catalogs for different database service plans are stored
   path: /etc/config/catalogs
-
-# storageClassName for storage
-storageClass: standard

--- a/docs/reference/service-broker_run.md
+++ b/docs/reference/service-broker_run.md
@@ -25,13 +25,15 @@ service-broker run [flags]
 
 ```
       --async                   Indicates whether the broker is handling the requests asynchronously.
+      --burst int               The maximum burst for throttle (default 100)
       --catalog-names strings   List of catalogs those can be run by this service-broker, comma separated.
       --catalog-path string     The path to the catalog. (default "/etc/config/catalogs")
   -h, --help                    help for run
       --insecure                use --insecure to use HTTP vs HTTPS.
-      --kube-config string      specify the kube config path to be used.
+      --kubeconfig string       Path to kubeconfig file with authorization information (the master location is set by the master flag).
+      --master string           The address of the Kubernetes API server (overrides any value in kubeconfig)
       --port int                use '--port' option to specify the port for broker to listen on. (default 8080)
-      --storage-class string    name of the storage-class for database storage. (default "standard")
+      --qps float               The maximum QPS to the master from this client (default 100)
       --tlsCert string          base-64 encoded PEM block to use as the certificate for TLS. If '--tlsCert' is used, then '--tlsKey' must also be used. If '--tlsCert' is not used, then TLS will not be used.
       --tlsKey string           base-64 encoded PEM block to use as the private key matching the TLS certificate. If '--tlsKey' is used, then '--tlsCert' must also be used.
 ```

--- a/hack/deploy/deployment.yaml
+++ b/hack/deploy/deployment.yaml
@@ -32,10 +32,8 @@ spec:
         - --catalog-names
         - "${SERVICE_BROKER_CATALOG_NAMES}"
         - -v
-        - "5"
+        - "3"
         - --logtostderr
-        - --storage-class
-        - ${SERVICE_BROKER_STORAGE_CLASS}
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/hack/deploy/install.sh
+++ b/hack/deploy/install.sh
@@ -112,7 +112,6 @@ export SERVICE_BROKER_IMAGE_PULL_POLICY=IfNotPresent
 export SERVICE_BROKER_PORT=8080
 export SERVICE_BROKER_CATALOG_PATH="/etc/config/catalogs"
 export SERVICE_BROKER_CATALOG_NAMES="kubedb"
-export SERVICE_BROKER_STORAGE_CLASS=standard
 export SERVICE_BROKER_UNINSTALL=0
 
 export APPSCODE_ENV=${APPSCODE_ENV:-prod}
@@ -138,7 +137,6 @@ show_help() {
     echo "    --port                    port number at which the broker will expose"
     echo "    --catalogPath             the path of catalogs for different service plans"
     echo "    --catalogNames            comma separated names of the catalogs for different service plans"
-    echo "    --storage-class           name of the storage-class for database storage"
     echo "    --uninstall               uninstall service-broker"
 }
 
@@ -181,10 +179,6 @@ while test $# -gt 0; do
             ;;
         --catalogNames*)
             export SERVICE_BROKER_CATALOG_NAMES=`echo $1 | sed -e 's/^[^=]*=//g'`
-            shift
-            ;;
-        --storage-class*)
-            export SERVICE_BROKER_STORAGE_CLASS=`echo $1 | sed -e 's/^[^=]*=//g'`
             shift
             ;;
         --uninstall)

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -18,19 +18,19 @@ import (
 // with. NewBroker is the place where you will initialize your
 // Broker Logic the parameters passed in.
 func NewBroker(s *ExtraOptions) (*Broker, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", s.KubeConfig)
+	config, err := clientcmd.BuildConfigFromFlags(s.MasterURL, s.KubeconfigPath)
 	if err != nil {
 		return nil, err
 	}
-	config.Burst = 100
-	config.QPS = 100
+	config.Burst = s.Burst
+	config.QPS = float32(s.QPS)
 
 	svccatClient, err := svcat_cs.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}
 
-	dbClient := dbsvc.NewClient(config, s.StorageClass)
+	dbClient := dbsvc.NewClient(config)
 	// For example, if your Broker Logic requires a parameter from the command
 	// line, you would unpack it from the Options and set it on the
 	// Broker Logic here.

--- a/pkg/broker/options.go
+++ b/pkg/broker/options.go
@@ -10,16 +10,20 @@ import (
 type ExtraOptions struct {
 	CatalogPath  string
 	CatalogNames []string
-	KubeConfig   string
 	Async        bool
-	StorageClass string
+
+	MasterURL      string
+	KubeconfigPath string
+	QPS            float64
+	Burst          int
 }
 
 func NewExtraOptions() *ExtraOptions {
 	return &ExtraOptions{
-		CatalogPath:  "/etc/config/catalogs",
-		Async:        false,
-		StorageClass: "standard",
+		CatalogPath: "/etc/config/catalogs",
+		Async:       false,
+		QPS:         100,
+		Burst:       100,
 	}
 }
 
@@ -27,11 +31,13 @@ func NewExtraOptions() *ExtraOptions {
 // It is called after the flags are added for the skeleton and before flag
 // parse is called.
 func (s *ExtraOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&s.MasterURL, "master", s.MasterURL, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.StringVar(&s.KubeconfigPath, "kubeconfig", s.KubeconfigPath, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
+	fs.Float64Var(&s.QPS, "qps", s.QPS, "The maximum QPS to the master from this client")
+	fs.IntVar(&s.Burst, "burst", s.Burst, "The maximum burst for throttle")
+
 	fs.StringVar(&s.CatalogPath, "catalog-path", s.CatalogPath, "The path to the catalog.")
 	fs.StringSliceVar(&s.CatalogNames, "catalog-names", s.CatalogNames,
 		"List of catalogs those can be run by this service-broker, comma separated.")
-	fs.StringVar(&s.KubeConfig, "kube-config", s.KubeConfig, "specify the kube config path to be used.")
 	fs.BoolVar(&s.Async, "async", s.Async, "Indicates whether the broker is handling the requests asynchronously.")
-	fs.StringVar(&s.StorageClass, "storage-class", s.StorageClass,
-		"name of the storage-class for database storage.")
 }

--- a/pkg/kubedb/broker.go
+++ b/pkg/kubedb/broker.go
@@ -24,16 +24,16 @@ type Client struct {
 	serviceProviders map[string]Provider
 }
 
-func NewClient(config *rest.Config, storageClassName string) *Client {
+func NewClient(config *rest.Config) *Client {
 	return &Client{
 		kubeClient: kubernetes.NewForConfigOrDie(config),
 		appClient:  appcat_cs.NewForConfigOrDie(config),
 		serviceProviders: map[string]Provider{
-			KubeDBServiceMySQL:         NewMySQLProvider(config, storageClassName),
-			KubeDBServicePostgreSQL:    NewPostgreSQLProvider(config, storageClassName),
-			KubeDBServiceElasticsearch: NewElasticsearchProvider(config, storageClassName),
-			KubeDBServiceMongoDB:       NewMongoDbProvider(config, storageClassName),
-			KubeDBServiceRedis:         NewRedisProvider(config, storageClassName),
+			KubeDBServiceMySQL:         NewMySQLProvider(config),
+			KubeDBServicePostgreSQL:    NewPostgreSQLProvider(config),
+			KubeDBServiceElasticsearch: NewElasticsearchProvider(config),
+			KubeDBServiceMongoDB:       NewMongoDbProvider(config),
+			KubeDBServiceRedis:         NewRedisProvider(config),
 			KubeDBServiceMemcached:     NewMemcachedProvider(config),
 		},
 	}

--- a/pkg/kubedb/elasticsearch.go
+++ b/pkg/kubedb/elasticsearch.go
@@ -18,14 +18,12 @@ import (
 )
 
 type ElasticsearchProvider struct {
-	extClient        cs.KubedbV1alpha1Interface
-	storageClassName string
+	extClient cs.KubedbV1alpha1Interface
 }
 
-func NewElasticsearchProvider(config *rest.Config, storageClassName string) Provider {
+func NewElasticsearchProvider(config *rest.Config) Provider {
 	return &ElasticsearchProvider{
-		extClient:        cs.NewForConfigOrDie(config),
-		storageClassName: storageClassName,
+		extClient: cs.NewForConfigOrDie(config),
 	}
 }
 

--- a/pkg/kubedb/mongodb.go
+++ b/pkg/kubedb/mongodb.go
@@ -18,14 +18,12 @@ import (
 )
 
 type MongoDbProvider struct {
-	extClient        cs.KubedbV1alpha1Interface
-	storageClassName string
+	extClient cs.KubedbV1alpha1Interface
 }
 
-func NewMongoDbProvider(config *rest.Config, storageClassName string) Provider {
+func NewMongoDbProvider(config *rest.Config) Provider {
 	return &MongoDbProvider{
-		extClient:        cs.NewForConfigOrDie(config),
-		storageClassName: storageClassName,
+		extClient: cs.NewForConfigOrDie(config),
 	}
 }
 

--- a/pkg/kubedb/mysql.go
+++ b/pkg/kubedb/mysql.go
@@ -17,14 +17,12 @@ import (
 )
 
 type MySQLProvider struct {
-	extClient        cs.KubedbV1alpha1Interface
-	storageClassName string
+	extClient cs.KubedbV1alpha1Interface
 }
 
-func NewMySQLProvider(config *rest.Config, storageClassName string) Provider {
+func NewMySQLProvider(config *rest.Config) Provider {
 	return &MySQLProvider{
-		extClient:        cs.NewForConfigOrDie(config),
-		storageClassName: storageClassName,
+		extClient: cs.NewForConfigOrDie(config),
 	}
 }
 

--- a/pkg/kubedb/postgres.go
+++ b/pkg/kubedb/postgres.go
@@ -22,10 +22,9 @@ type PostgreSQLProvider struct {
 	storageClassName string
 }
 
-func NewPostgreSQLProvider(config *rest.Config, storageClassName string) Provider {
+func NewPostgreSQLProvider(config *rest.Config) Provider {
 	return &PostgreSQLProvider{
-		extClient:        cs.NewForConfigOrDie(config),
-		storageClassName: storageClassName,
+		extClient: cs.NewForConfigOrDie(config),
 	}
 }
 

--- a/pkg/kubedb/provider.go
+++ b/pkg/kubedb/provider.go
@@ -52,11 +52,7 @@ func (p ProvisionInfo) applyToMetadata(meta *metav1.ObjectMeta) error {
 		}
 	}
 
-	if meta.Name != "" {
-		p.InstanceName = meta.Name
-	} else {
-		meta.Name = p.InstanceName
-	}
+	meta.Name = p.InstanceName
 	meta.Namespace = p.Namespace
 
 	// set instance id at labels

--- a/pkg/kubedb/redis.go
+++ b/pkg/kubedb/redis.go
@@ -17,14 +17,12 @@ import (
 )
 
 type RedisProvider struct {
-	extClient        cs.KubedbV1alpha1Interface
-	storageClassName string
+	extClient cs.KubedbV1alpha1Interface
 }
 
-func NewRedisProvider(config *rest.Config, storageClassName string) Provider {
+func NewRedisProvider(config *rest.Config) Provider {
 	return &RedisProvider{
-		extClient:        cs.NewForConfigOrDie(config),
-		storageClassName: storageClassName,
+		extClient: cs.NewForConfigOrDie(config),
 	}
 }
 


### PR DESCRIPTION
- remove storageclassname flag
- add qps, burst flags
- replace kube-config with master & kubeconfig flags
- remove metadata.name from params since we are taking it from ServiceInstance name

Signed-off-by: Tamal Saha <tamal@appscode.com>
