### PR TITLE
Use absolute path as aliases for reference docs

### DIFF
--- a/docs/reference/service-broker.md
+++ b/docs/reference/service-broker.md
@@ -11,7 +11,7 @@ product_name: service-broker
 menu_name: product_service-broker_0.3.1
 section_menu_id: reference
 aliases:
-  - products/service-broker/0.3.1/reference/
+  - /products/service-broker/0.3.1/reference/
 
 ---
 ## service-broker

--- a/hack/gendocs/main.go
+++ b/hack/gendocs/main.go
@@ -47,7 +47,7 @@ menu_name: product_service-broker_{{ .Version }}
 section_menu_id: reference
 {{- if .RootCmd }}
 aliases:
-  - products/service-broker/{{ .Version }}/reference/
+  - /products/service-broker/{{ .Version }}/reference/
 {{ end }}
 ---
 `))


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>